### PR TITLE
Improve auth error handling and typings

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -34,7 +34,9 @@ export default function ForgotPasswordPage() {
       await passwordReset(values.email);
       setIsSent(true);
     } catch (error) {
-      toast({ variant: 'destructive', title: 'Error', description: error.message });
+      const message =
+        error instanceof Error ? error.message : 'An unexpected error occurred';
+      toast({ variant: 'destructive', title: 'Error', description: message });
     } finally {
         setIsLoading(false);
     }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,23 +37,40 @@ export default function LoginPage() {
     setIsLoading(true);
     try {
       const auth = getAuth();
-      await setPersistence(auth, values.rememberMe ? browserLocalPersistence : browserSessionPersistence);
+      await setPersistence(
+        auth,
+        values.rememberMe ? browserLocalPersistence : browserSessionPersistence
+      );
       await signIn(values.email, values.password);
       router.push('/');
     } catch (error) {
-      toast({ variant: 'destructive', title: 'Login Failed', description: error.message });
+      const message =
+        error instanceof Error ? error.message : 'An unexpected error occurred';
+      toast({
+        variant: 'destructive',
+        title: 'Login Failed',
+        description: message,
+      });
       setIsLoading(false);
     }
   };
-  
+
   const handleGoogleSignIn = async () => {
       setIsLoading(true);
       try {
-          await signInWithGoogle();
-          router.push('/create-profile');
-      } catch(error) {
-          toast({ variant: 'destructive', title: 'Google Sign-In Failed', description: error.message });
-          setIsLoading(false);
+        await signInWithGoogle();
+        router.push('/create-profile');
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred';
+        toast({
+          variant: 'destructive',
+          title: 'Google Sign-In Failed',
+          description: message,
+        });
+        setIsLoading(false);
       }
   }
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -39,19 +39,33 @@ export default function SignupPage() {
       await signUp(values.email, values.password);
       router.push('/create-profile');
     } catch (error) {
-      toast({ variant: 'destructive', title: 'Sign Up Failed', description: error.message });
+      const message =
+        error instanceof Error ? error.message : 'An unexpected error occurred';
+      toast({
+        variant: 'destructive',
+        title: 'Sign Up Failed',
+        description: message,
+      });
       setIsLoading(false);
     }
   };
-  
+
   const handleGoogleSignIn = async () => {
       setIsLoading(true);
       try {
-          await signInWithGoogle();
-          router.push('/create-profile');
-      } catch(error) {
-          toast({ variant: 'destructive', title: 'Google Sign-In Failed', description: error.message });
-          setIsLoading(false);
+        await signInWithGoogle();
+        router.push('/create-profile');
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred';
+        toast({
+          variant: 'destructive',
+          title: 'Google Sign-In Failed',
+          description: message,
+        });
+        setIsLoading(false);
       }
   }
 

--- a/src/components/auth/with-auth.tsx
+++ b/src/components/auth/with-auth.tsx
@@ -3,11 +3,11 @@
 
 import { useAuth } from '@/context/auth-context';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, ComponentType } from 'react';
 import { Loader2 } from 'lucide-react';
 
-const withAuth = (WrappedComponent) => {
-  const Wrapper = (props) => {
+const withAuth = <P extends object>(WrappedComponent: ComponentType<P>) => {
+  const Wrapper = (props: P) => {
     const { user, loading } = useAuth();
     const router = useRouter();
 
@@ -27,7 +27,7 @@ const withAuth = (WrappedComponent) => {
 
     return <WrappedComponent {...props} />;
   };
-  
+
   Wrapper.displayName = `withAuth(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`;
 
   return Wrapper;

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -2,7 +2,8 @@
 "use client";
 
 import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
-import { onAuthStateChange, User, getUserProfile } from '@/lib/auth';
+import { onAuthStateChange, getUserProfile } from '@/lib/auth';
+import type { User } from 'firebase/auth';
 import { Loader2 } from 'lucide-react';
 
 interface UserProfile {
@@ -29,7 +30,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChange(async (user) => {
+    const unsubscribe = onAuthStateChange(async (user: User | null) => {
       setLoading(true);
       setUser(user);
       if (user) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,23 +10,19 @@ import {
   onAuthStateChanged,
   sendPasswordResetEmail,
   updateProfile,
-  User,
-  getAuth,
-  setPersistence,
-  browserSessionPersistence,
-  browserLocalPersistence
+  User
 } from "firebase/auth";
 import { auth, db, storage } from "./firebase";
 import { doc, setDoc, getDoc } from "firebase/firestore";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 
 // Sign Up
-export const signUp = async (email, password) => {
+export const signUp = async (email: string, password: string) => {
   return createUserWithEmailAndPassword(auth, email, password);
 };
 
 // Sign In
-export const signIn = async (email, password) => {
+export const signIn = async (email: string, password: string) => {
   return signInWithEmailAndPassword(auth, email, password);
 };
 
@@ -42,17 +38,27 @@ export const logout = () => {
 };
 
 // Password Reset
-export const passwordReset = (email) => {
+export const passwordReset = (email: string) => {
   return sendPasswordResetEmail(auth, email);
 };
 
 // Auth State Change
-export const onAuthStateChange = (callback) => {
+export const onAuthStateChange = (callback: (user: User | null) => void) => {
   return onAuthStateChanged(auth, callback);
 };
 
+interface UserProfileInput {
+  username: string;
+  displayName: string;
+  bio?: string;
+  photoFile?: File;
+}
+
 // Create User Profile
-export const createUserProfile = async (user, { username, displayName, bio, photoFile }) => {
+export const createUserProfile = async (
+  user: User | null,
+  { username, displayName, bio, photoFile }: UserProfileInput
+) => {
     if (!user) return;
 
     let photoURL = user.photoURL || '';
@@ -81,7 +87,7 @@ export const createUserProfile = async (user, { username, displayName, bio, phot
 };
 
 // Get User Profile
-export const getUserProfile = async (uid) => {
+export const getUserProfile = async (uid: string) => {
     if (!uid) return null;
     const userRef = doc(db, "users", uid);
     const userSnap = await getDoc(userRef);


### PR DESCRIPTION
## Summary
- refine error handling in login, signup, and password reset pages
- add type-safe higher-order auth wrapper and context
- type auth library functions for sign in, sign up, and profile management

## Testing
- `npm run typecheck` *(fails: Object literal may only specify known properties 'currentDate'; Property 'tooltip' does not exist on type)*
- `npm run lint` *(interactive prompt prevented completion)*

------
https://chatgpt.com/codex/tasks/task_b_68961409f8c083258bd9308933e5f88e