### PR TITLE
Handle missing Google sign-in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Google authentication
+
+Ensure Google sign-in is enabled in your Firebase project before deploying. Users will encounter an `auth/configuration-not-found` error if Google authentication is not configured. Enable the provider in the Firebase console or contact support to set it up.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,6 +16,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { useToast } from '@/hooks/use-toast';
 import { signIn, signInWithGoogle } from '@/lib/auth';
 import { getAuth, setPersistence, browserLocalPersistence, browserSessionPersistence } from 'firebase/auth';
+import { FirebaseError } from 'firebase/app';
 
 const formSchema = z.object({
   email: z.string().email('Invalid email address.'),
@@ -61,10 +62,11 @@ export default function LoginPage() {
         await signInWithGoogle();
         router.push('/create-profile');
       } catch (error) {
+        const firebaseError = error as FirebaseError;
         const message =
-          error instanceof Error
-            ? error.message
-            : 'An unexpected error occurred';
+          firebaseError.code === 'auth/configuration-not-found'
+            ? 'Google sign-in is not configured. Please contact support or enable Google sign-in.'
+            : firebaseError.message || 'An unexpected error occurred';
         toast({
           variant: 'destructive',
           title: 'Google Sign-In Failed',

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -13,6 +13,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { signUp, signInWithGoogle } from '@/lib/auth';
+import { FirebaseError } from 'firebase/app';
 
 const formSchema = z.object({
   email: z.string().email('Invalid email address.'),
@@ -56,10 +57,11 @@ export default function SignupPage() {
         await signInWithGoogle();
         router.push('/create-profile');
       } catch (error) {
+        const firebaseError = error as FirebaseError;
         const message =
-          error instanceof Error
-            ? error.message
-            : 'An unexpected error occurred';
+          firebaseError.code === 'auth/configuration-not-found'
+            ? 'Google sign-in is not configured. Please contact support or enable Google sign-in.'
+            : firebaseError.message || 'An unexpected error occurred';
         toast({
           variant: 'destructive',
           title: 'Google Sign-In Failed',


### PR DESCRIPTION
## Summary
- Add FirebaseError handling for Google sign-in/sign-up to surface configuration issues
- Document requirement to enable Google authentication before deploying

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*
- `npm run typecheck` *(fails: Object literal may only specify known properties)*

------
https://chatgpt.com/codex/tasks/task_b_68961894297c8325884655314a815632